### PR TITLE
Allow form to be saved

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,6 @@ Metrics/AbcSize:
 Style/MixinUsage:
   Exclude:
     - 'bin/*'
+Style/WordArray:
+  Exclude:
+    - 'db/schema.rb'

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -23,7 +23,11 @@ class ApplicationsController < MainController
   end
   
   def find
-    redirect_to new_application_you_and_your_family_path(application)
+    if application.current_path
+      redirect_to application.current_path
+    else
+      redirect_to new_application_you_and_your_family_path(application)
+    end
   rescue ActiveRecord::RecordNotFound
     flash[:error] = I18n.t('application.invalid_code')
     render :index

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -2,6 +2,7 @@ class ApplicationsController < MainController
   expose :application, :get_application
   
   prepend_before_action :update_application
+  before_action :set_current_path, only: [:show]
   
   def index; end
   

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -1,6 +1,12 @@
 class MainController < ActionController::Base
   protect_from_forgery with: :exception
+  before_action :set_current_path, only: [:show]
   
   def index; end
+  
+  def set_current_path
+    return unless defined?(application)
+    application.update_attribute(:current_path, request.path)
+  end
   
 end

--- a/db/migrate/20180328140159_add_current_path_to_application.rb
+++ b/db/migrate/20180328140159_add_current_path_to_application.rb
@@ -1,0 +1,5 @@
+class AddCurrentPathToApplication < ActiveRecord::Migration[5.1]
+  def change
+    add_column :applications, :current_path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180328103230) do
+ActiveRecord::Schema.define(version: 20180328140159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,37 +106,38 @@ ActiveRecord::Schema.define(version: 20180328103230) do
     t.boolean "agree_to_la_contact"
     t.string "signature"
     t.boolean "eligible"
+    t.string "current_path"
     t.index ["support_carer_id"], name: "index_applications_on_support_carer_id"
   end
 
   create_table "applications_adults", id: false, force: :cascade do |t|
     t.bigint "application_id", null: false
     t.bigint "person_id", null: false
-    t.index %w[application_id person_id], name: "index_applications_adults_on_application_id_and_person_id"
+    t.index ["application_id", "person_id"], name: "index_applications_adults_on_application_id_and_person_id"
   end
 
   create_table "applications_adults_elsewhere", id: false, force: :cascade do |t|
     t.bigint "application_id", null: false
     t.bigint "person_id", null: false
-    t.index %w[application_id person_id], name: "adults_elsewhere_index"
+    t.index ["application_id", "person_id"], name: "adults_elsewhere_index"
   end
 
   create_table "applications_children", id: false, force: :cascade do |t|
     t.bigint "application_id", null: false
     t.bigint "person_id", null: false
-    t.index %w[application_id person_id], name: "index_applications_children_on_application_id_and_person_id"
+    t.index ["application_id", "person_id"], name: "index_applications_children_on_application_id_and_person_id"
   end
 
   create_table "applications_children_elsewhere", id: false, force: :cascade do |t|
     t.bigint "application_id", null: false
     t.bigint "person_id", null: false
-    t.index %w[application_id person_id], name: "children_elsewhere_index"
+    t.index ["application_id", "person_id"], name: "children_elsewhere_index"
   end
 
   create_table "applications_referees", id: false, force: :cascade do |t|
     t.bigint "application_id", null: false
     t.bigint "person_id", null: false
-    t.index %w[application_id person_id], name: "index_applications_referees_on_application_id_and_person_id"
+    t.index ["application_id", "person_id"], name: "index_applications_referees_on_application_id_and_person_id"
   end
 
   create_table "people", force: :cascade do |t|

--- a/spec/controllers/applications/you_and_your_family_controller_spec.rb
+++ b/spec/controllers/applications/you_and_your_family_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Applications::YouAndYourFamilyController, type: :controller do
+  
+  let(:application) { Fabricate(:application) }
+  
+  describe 'show' do
+    
+    it 'saves the current path' do
+      get :show, params: { application_id: application.code, id: :dob }
+      application.reload
+      expect(application.current_path).to eq("/applications/#{application.code}/you_and_your_family/dob")
+    end
+    
+  end
+  
+end

--- a/spec/features/save_progress.feature
+++ b/spec/features/save_progress.feature
@@ -1,0 +1,10 @@
+Feature: Save Progress
+
+  Background:
+    Given I have started an application
+    And I am answering the adults living at home step of the you and your family form
+  
+  Scenario: Takes me back to the correct step
+    And I am on the applications
+    And I enter the correct code
+    Then I should be on the 'adults_living_at_home' step


### PR DESCRIPTION
Every time a user navigates to the next step, their position in the form is saved (currently, it's the whole path, which is not ideal, but as the form jumps around a lot, it's the only way to be sure). If they go away and navigate back to /applications (this needs to be linked from somewhere) and enter their code, they'll be able to carry on from where they left off.