### PR TITLE
Handle invalid dates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ Metrics/BlockLength:
   Exclude:
     - 'db/**/*.rb'
     - 'config/environments/*.rb'
+    - 'spec/**/*.rb'
 Metrics/MethodLength:
   Exclude:
     - 'db/**/*.rb'

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,4 +4,46 @@ class ApplicationRecord < ActiveRecord::Base
   def self.human_enum_name(enum_name, enum_value)
     I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name.to_s.pluralize}.#{enum_value}")
   end
+
+  def update_attributes(attrs = {})
+    super parse_dates(attrs)
+  end
+  
+  def parse_dates(attrs)
+    # First fetch any nested attributes
+    attrs.clone.each do |k, v|
+      next unless v.is_a?(Hash)
+      # If this is a hash, it's a nested attribute, so check for dates
+      attrs = parse_nested_dates(k, attrs)
+    end
+    # Now marshal the rest of the dates
+    marshal_dates(self.class, attrs)
+  end
+  
+  def parse_nested_dates(key, attrs)
+    klass = Object.const_get key.split('_attributes').first.classify
+    attrs[key] = marshal_dates(klass, attrs[key])
+    attrs
+  end
+  
+  def marshal_dates(klass, attrs)
+    # Get all the columns in the class that have a date type
+    date_columns = klass.columns_hash.select { |_k, value| value.type == :date }.keys
+    date_columns.each { |c| attrs = parse_date(attrs, c) }
+    attrs
+  end
+  
+  def parse_date(attrs, property)
+    # Gather up all the date parts
+    keys = attrs.keys.select { |k| k =~ /#{property}/ }.sort
+    return attrs if keys.empty?
+    values = []
+    keys.each do |k|
+      values << attrs[k]
+      attrs.delete(k)
+    end
+    # Set the date as a standard ISO8601 date
+    attrs[property] = values.join('-')
+    attrs
+  end
 end

--- a/spec/controllers/applications/addresses_controller_spec.rb
+++ b/spec/controllers/applications/addresses_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module Applications
-  describe AddressesController, type: :controller do # rubocop:disable Metrics/BlockLength
+  describe AddressesController, type: :controller do
     let!(:application) { Fabricate(:application) }
     let!(:address) { Fabricate(:address, application: application) }
     

--- a/spec/mailers/applications_mailer.rb
+++ b/spec/mailers/applications_mailer.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe ApplicationsMailer, type: :mailer do # rubocop:disable Metrics/BlockLength
-  describe 'eligibility' do # rubocop:disable Metrics/BlockLength
+RSpec.describe ApplicationsMailer, type: :mailer do
+  describe 'eligibility' do
     
     let(:mail) { ApplicationsMailer.eligibility(application.id) }
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe Application, type: :model do # rubocop:disable Metrics/BlockLength
+RSpec.describe Application, type: :model do
   
   let(:application) { Fabricate(:application) }
   let(:address) { Fabricate(:address) }
 
-  describe 'people relationships' do # rubocop:disable Metrics/BlockLength
+  describe 'people relationships' do
     
     let(:children) { Fabricate.times(3, :child) }
     let(:adults) { Fabricate.times(2, :adult) }
@@ -73,6 +73,52 @@ RSpec.describe Application, type: :model do # rubocop:disable Metrics/BlockLengt
     application.save
     application.reload
     expect(application.previous_agency_address).to eq(address)
+  end
+  
+  describe 'parsing dates' do
+    
+    let(:application) { Fabricate(:application) }
+    
+    it 'returns invalid error if date is invalid' do
+      valid = application.update_attributes('current_step' => 'court_date',
+                                            'court_date(1i)' => '9999',
+                                            'court_date(2i)' => '99',
+                                            'court_date(3i)' => '99')
+      expect(valid).to eq(false)
+    end
+    
+    it 'returns valid if date is valid' do
+      valid = application.update_attributes('current_step' => 'court_date',
+                                            'court_date(1i)' => '2012',
+                                            'court_date(2i)' => '12',
+                                            'court_date(3i)' => '12')
+      expect(valid).to eq(true)
+    end
+    
+    context 'with nested attribute' do
+      
+      it 'returns invalid error if date is invalid' do
+        valid = application.update_attributes('current_step' => 'dob',
+                                              'applicant_attributes' => {
+                                                'date_of_birth(1i)' => '9999',
+                                                'date_of_birth(2i)' => '99',
+                                                'date_of_birth(3i)' => '99'
+                                              })
+        expect(valid).to eq(false)
+      end
+      
+      it 'returns valid if date is valid' do
+        valid = application.update_attributes('current_step' => 'dob',
+                                              'applicant_attributes' => {
+                                                'date_of_birth(1i)' => '2012',
+                                                'date_of_birth(2i)' => '12',
+                                                'date_of_birth(3i)' => '12'
+                                              })
+        expect(valid).to eq(true)
+      end
+      
+    end
+    
   end
     
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,7 @@ require 'rspec/rails'
 
 ActiveRecord::Migration.maintain_test_schema!
 
-RSpec.configure do |config| # rubocop:disable Metrics/BlockLength
+RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   config.use_transactional_fixtures = false


### PR DESCRIPTION
Before, invalid dates (such as 99/99/9999) were raising an `ActiveRecord::MultiparameterAssignmentErrors` error. This marshals the dates back to a standard ISO8601 date format, which then causes a normal activerecord validation error.